### PR TITLE
Export APIs on MSVC

### DIFF
--- a/include/plugins/3dapi/ifsg_defs.h
+++ b/include/plugins/3dapi/ifsg_defs.h
@@ -31,7 +31,7 @@
 #ifndef IFSG_DEFS_H
 #define IFSG_DEFS_H
 
-#if defined(__MINGW32__) || defined( MSVC )
+#if defined(__MINGW32__) || defined( _MSC_VER )
     #define APIEXPORT __declspec(dllexport)
     #define APIIMPORT __declspec(dllimport)
     #define APILOCAL


### PR DESCRIPTION
MSVC sets _MSC_VER, not MSVC as a preprocessor definition
